### PR TITLE
feat: wallet connectivity

### DIFF
--- a/base_layer/p2p/src/config.rs
+++ b/base_layer/p2p/src/config.rs
@@ -103,6 +103,8 @@ pub struct P2pConfig {
         deserialize_with = "deserialize_from_str",
         serialize_with = "serialize_string"
     )]
+    /// If set to `Private`, the node will not be used as a public relay
+    /// (Base node default: `Auto`, Wallet default: `Private`)
     pub reachability_mode: ReachabilityMode,
     /// The global maximum allowed RPC sessions.
     /// Default: 100

--- a/base_layer/wallet/src/connectivity_service/service.rs
+++ b/base_layer/wallet/src/connectivity_service/service.rs
@@ -66,6 +66,7 @@ pub struct WalletConnectivityService {
     request_receiver: mpsc::Receiver<WalletConnectivityRequest>,
     network_handle: NetworkHandle,
     base_node_watch_receiver: watch::Receiver<Option<BaseNodePeerManager>>,
+    base_node_watch: Watch<Option<BaseNodePeerManager>>,
     current_pool: Option<ClientPoolContainer>,
     online_status_watch: Watch<OnlineStatus>,
     pending_requests: Vec<ReplyOneshot>,
@@ -97,6 +98,7 @@ impl WalletConnectivityService {
             request_receiver,
             network_handle,
             base_node_watch_receiver: base_node_watch.get_receiver(),
+            base_node_watch,
             current_pool: None,
             pending_requests: Vec::new(),
             online_status_watch,
@@ -290,6 +292,7 @@ impl WalletConnectivityService {
     }
 
     async fn disconnect_base_node(&mut self, peer_id: PeerId) {
+        trace!(target: LOG_TARGET, "Disconnecting base node '{}'...", peer_id);
         if let Some(pool) = self.current_pool.take() {
             pool.close().await;
         }
@@ -298,9 +301,8 @@ impl WalletConnectivityService {
         }
     }
 
-    async fn setup_base_node_connection(&mut self, mut peer_manager: BaseNodePeerManager) {
+    async fn setup_base_node_connection(&mut self, peer_manager: BaseNodePeerManager) {
         let mut peer = peer_manager.select_next_peer_if_attempted();
-        let peer_id = peer.peer_id();
 
         loop {
             self.set_online_status(OnlineStatus::Connecting);
@@ -317,13 +319,12 @@ impl WalletConnectivityService {
 
             match self.try_setup_rpc_pool(peer).await {
                 Ok(true) => {
-                    if let Err(e) = self.notify_pending_requests().await {
-                        warn!(target: LOG_TARGET, "Error notifying pending RPC requests: {}", e);
-                    }
+                    self.base_node_watch.send(Some(peer_manager.clone()));
+                    self.notify_pending_requests().await;
                     self.set_online_status(OnlineStatus::Online);
                     debug!(
                         target: LOG_TARGET,
-                        "Wallet is ONLINE and connected to base node '{}'", peer
+                        "Wallet is ONLINE and connected to base node '{}'", peer.peer_id()
                     );
                     break;
                 },
@@ -332,28 +333,17 @@ impl WalletConnectivityService {
                         target: LOG_TARGET,
                         "The peer has changed while connecting. Attempting to connect to new base node."
                     );
-
-                    // NOTE: we do not strictly need to update our local copy of BaseNodePeerManager since state is
-                    // atomically shared. However, since None is a possibility (although in practice
-                    // it should never be) we handle that here.
-                    peer_manager = match self.get_base_node_peer_manager() {
-                        Some(pm) => pm,
-                        None => {
-                            warn!(target: LOG_TARGET, "⚠️ NEVER HAPPEN: Base node peer manager set to None while connecting");
-                            return;
-                        },
-                    };
-                    self.disconnect_base_node(peer_id).await;
+                    self.disconnect_base_node(peer.peer_id()).await;
                     self.set_online_status(OnlineStatus::Offline);
                 },
                 Err(WalletConnectivityError::DialError(DialError::Aborted)) => {
                     debug!(target: LOG_TARGET, "Dial was cancelled.");
-                    self.disconnect_base_node(peer_id).await;
+                    self.disconnect_base_node(peer.peer_id()).await;
                     self.set_online_status(OnlineStatus::Offline);
                 },
                 Err(e) => {
                     warn!(target: LOG_TARGET, "{}", e);
-                    self.disconnect_base_node(peer_id).await;
+                    self.disconnect_base_node(peer.peer_id()).await;
                     self.set_online_status(OnlineStatus::Offline);
                 },
             }
@@ -361,7 +351,7 @@ impl WalletConnectivityService {
             // Select the next peer (if available)
             let next_peer = peer_manager.select_next_peer();
             // If we only have one peer in the list, wait a bit before retrying
-            if peer_id == next_peer.peer_id() {
+            if peer.peer_id() == next_peer.peer_id() {
                 debug!(target: LOG_TARGET,
                     "Only single peer in base node peer list. Waiting {}s before retrying again ...",
                     CONNECTIVITY_WAIT.as_secs()
@@ -385,7 +375,7 @@ impl WalletConnectivityService {
             .network_handle
             .dial_peer(
                 DialOpts::peer_id(peer.peer_id())
-                    .condition(PeerCondition::Disconnected)
+                    .condition(PeerCondition::NotDialing)
                     .addresses(peer.addresses().to_vec())
                     .build(),
             )
@@ -430,16 +420,21 @@ impl WalletConnectivityService {
         Ok(true)
     }
 
-    async fn notify_pending_requests(&mut self) -> Result<(), WalletConnectivityError> {
+    async fn notify_pending_requests(&mut self) {
         let current_pending = mem::take(&mut self.pending_requests);
+        let mut count = 0;
+        let current_pending_len = current_pending.len();
         for reply in current_pending {
             if reply.is_canceled() {
                 continue;
             }
-
+            count += 1;
+            trace!(target: LOG_TARGET, "Handle {} of {} pending RPC pool requests", count, current_pending_len);
             self.handle_pool_request(reply).await;
         }
-        Ok(())
+        if !self.pending_requests.is_empty() {
+            warn!(target: LOG_TARGET, "{} of {} pending RPC pool requests not handled", count, current_pending_len);
+        }
     }
 }
 

--- a/common/config/presets/c_base_node_c.toml
+++ b/common/config/presets/c_base_node_c.toml
@@ -126,6 +126,11 @@ blockchain_sync_config.rpc_deadline = 240
 # _NOTE_: If using the `tor` transport type, public_addresses will be ignored and an onion address will be
 # automatically configured
 #public_addresses = ["/ip4/172.2.3.4/tcp/18189",]
+# The multiaddrs to listen on.
+# Default: ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"]
+#listen_addresses = ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"]
+# (Base node default: `auto`, Wallet default: `private`)
+#reachability_mode = auto
 
 # Optionally bind an additional TCP socket for inbound Tari P2P protocol commms.
 # Use cases include:
@@ -163,4 +168,4 @@ blockchain_sync_config.rpc_deadline = 240
 # If true, and the maximum per peer RPC sessions is reached, the RPC server will close an old session and replace it
 # with a new session. If false, the RPC server will reject the new session and preserve the older session.
 # (default value = true).
-#pub cull_oldest_peer_rpc_connection_on_full = true
+#cull_oldest_peer_rpc_connection_on_full = true

--- a/common/config/presets/d_console_wallet.toml
+++ b/common/config/presets/d_console_wallet.toml
@@ -166,6 +166,12 @@ event_channel_size = 3500
 # _NOTE_: If using the `tor` transport type, public_address will be ignored and an onion address will be
 # automatically configured
 #public_addresses = ["/ip4/172.2.3.4/tcp/18188",]
+# The multiaddrs to listen on.
+# Default: ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"]
+#listen_addresses = ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic"]
+# If set to `Private`, the node will not be used as a public relay
+# (Base node default: `auto`, Wallet default: `private`)
+#reachability_mode = private
 
 # Optionally bind an additional TCP socket for inbound Tari P2P protocol commms.
 # Use cases include:
@@ -204,7 +210,6 @@ event_channel_size = 3500
 # sessions.
 #rpc_max_simultaneous_sessions = 100
 # The maximum comms RPC sessions allowed per peer (default value = 10).
-#rpc_max_sessions_per_peer = 10
 #rpc_max_sessions_per_peer = 10
 # If true, and the maximum per peer RPC sessions is reached, the RPC server will close an old session and replace it
 # with a new session. If false, the RPC server will reject the new session and preserve the older session.

--- a/network/rpc_framework/src/client/pool.rs
+++ b/network/rpc_framework/src/client/pool.rs
@@ -108,10 +108,21 @@ where
                         Ok(c) => c,
                         // This is an edge case where the remote node does not have any further sessions available. This
                         // is gracefully handled by returning one of the existing used sessions.
-                        Err(RpcClientPoolError::NoMoreRemoteRpcSessions) => self
-                            .get_least_used()
-                            .ok_or(RpcClientPoolError::NoMoreRemoteRpcSessions)?,
+                        Err(RpcClientPoolError::NoMoreRemoteRpcSessions) => {
+                            trace!(
+                                target: LOG_TARGET,
+                                "get_least_used_or_connect: no more remote rpc sessions, trying least used."
+                            );
+                            self.get_least_used().ok_or({
+                                trace!(
+                                    target: LOG_TARGET,
+                                    "get_least_used_or_connect: lest used client not found."
+                                );
+                                RpcClientPoolError::NoMoreRemoteRpcSessions
+                            })?
+                        },
                         Err(err) => {
+                            trace!(target: LOG_TARGET, "get_least_used_or_connect: returning error ({})", err);
                             return Err(err);
                         },
                     }
@@ -120,6 +131,7 @@ where
 
             if !client.is_connected() {
                 self.prune();
+                trace!(target: LOG_TARGET, "get_least_used_or_connect: new client is not connected, pruning");
                 continue;
             }
 


### PR DESCRIPTION
Description
---
- Updated wallet connectivity logic to:
  - cater for a first dial condition when the peer is either connected or disconnected;
  - update the base node watch with the new base node peer manager state when a base node has been connected.
- Added more trace logs.

Motivation and Context
---
- Incorrect dial condition for a first dial attempt
```
2024-11-06 11:57:22.756802700 [wallet::connectivity] DEBUG Attempting to connect to base node peer 
  'Peer(12D3L7AVC3KnrNWkKic75qhXbXro8n5RB39c7wXLf1Efy57hQP7n, Sr25519, [/ip4/192.168.5.114/udp/62620/quic-v1, ])'... 
  (last attempt None)
2024-11-06 11:57:22.757346500 [wallet::connectivity] WARN  Network error: Dial failed: Dial error: dial condition was 
  configured to only happen when disconnected (`PeerCondition::Disconnected`), but node is already connected, thus 
  cancelling new dial.
```
- The console wallet TUI was not updated with new base node peer connection information.

How Has This Been Tested?
---
System-level testing
